### PR TITLE
Redo how the DB tracks time

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,13 @@ DB_ERROR_MESSAGE = ('''You\'re trying to use a DB engine '''
                     '''that\'s not currently supported. '''
                     '''Try again, specifying `mysql` or `sqlite`.''')
 
+time_map = {
+    5: 20,
+    10: 10,
+    15: 4,
+    30: 2,
+}
+
 
 def update_args(args):
     cfg = ConfigParser.ConfigParser()
@@ -18,3 +25,6 @@ def update_args(args):
             args[field] = field_value
 
     return args
+
+def map_time(arg):
+    return time_map[arg]

--- a/analyze.py
+++ b/analyze.py
@@ -1,4 +1,5 @@
 import argparse
+import sqlite3
 import subprocess
 import sys
 
@@ -6,7 +7,6 @@ import numpy as np
 import pandas as pd
 import pandas.io.sql as pdsql
 import pymysql as mdb
-import sqlite3
 
 from datetime import datetime
 
@@ -38,8 +38,14 @@ def make_graph(d):
     gp.stdin.flush()
 
 
+def round_time(df, rd):
+    return [round(x/np.timedelta64(1, 'h') * rd) / rd for x in df[0]]
+
+
 def run(args_dict):
     args_dict = update_args(args_dict)
+    if args_dict['round']:
+        args_dict['round'] = map_time(args_dict['round'])
 
     if len(args_dict['date'])==1:
         args_dict['date'].append(args_dict['date'][0])
@@ -60,12 +66,21 @@ def run(args_dict):
     df = df[(df.date>=args_dict['date'][0]) & (df.date<=args_dict['date'][1])]
 
     vals = df.groupby(['date', 'project']).apply(lambda x: (x['end'] - x['start']).sum())
-    graph = (vals
-             .reset_index()
-             .pivot(index='date', columns='project', values=0)
-             .reset_index(level=0)
-             .fillna(0))
-    graph.date = graph.date.apply(lambda x: datetime.strftime(x, '%m/%d/%Y'))
+
+    if args_dict['round']:
+        vals[0] = round_time(vals, args_dict['round'])
+
+    if args_dict['analysis'] in ['all', 'graph']:
+        vals_graph = vals.copy()
+        if not args_dict['round']:
+            vals_graph[0] = round_time(vals_graph, 15)
+
+        graph = (vals_graph
+                 .reset_index()
+                 .pivot(index='date', columns='project', values=0)
+                 .reset_index(level=0)
+                 .fillna(0))
+        graph.date = graph.date.apply(lambda x: datetime.strftime(x, '%m/%d/%Y'))
 
     if args_dict['analysis']=='table':
         print vals
@@ -84,6 +99,8 @@ if __name__ == '__main__':
     parser.add_argument('-a', '--analysis', required=True, choices=['table', 'graph',
                         'all'], help='Enter how data should be analyzed - `table`, '
                         '`graph`, or `all`.')
+    parser.add_argument('-r', '--round', required=False, type=int, choices=[5, 10, 15, 30],
+                        help='Optional; rounds times to specified minute interval.')
     parser.add_argument('--host', required=False, help='Database host; will default to '
                         'config settings.')
     parser.add_argument('--db', required=False, help='Database name; will default to '

--- a/analyze.py
+++ b/analyze.py
@@ -13,6 +13,11 @@ from datetime import datetime
 from tt import *
 
 
+def convert_str_time(arr):
+    tmp = arr.apply(lambda x: x.split(':'))
+    return [np.timedelta64(int(x[0])*60 + int(x[1]), 'm') for x in tmp]
+
+
 def write_plot(d, nbr):
     for i in xrange(1, nbr):
         if i==1:
@@ -64,6 +69,9 @@ def run(args_dict):
     df.date = df.date.apply(lambda x: datetime.strptime(x, '%m/%d/%Y'))
 
     df = df[(df.date>=args_dict['date'][0]) & (df.date<=args_dict['date'][1])]
+    if args_dict['dbengine'] == 'sqlite':
+        df.start = convert_str_time(df.start)
+        df.end = convert_str_time(df.end)
 
     vals = df.groupby(['date', 'project']).apply(lambda x: (x['end'] - x['start']).sum())
 


### PR DESCRIPTION
When originally set up, `tt` tracked time as a float, i.e., 9:15am was tracked as 9.25. This PR adds to work done to switch this over to an actual time system, i.e., HH:MM. In addition, it adds the ability to round time values in analysis.

Often, a timekeeping system needs time entered as some type of float, not in hours and minutes. Moreover, those values are often rounded to time points, like every 5, 10, 15, or 30 minutes. This PR adds functionality to round time so that when the table shows, it provides the float that would be entered in a timekeeping system. This is an optional argument and currently available for intervals of 5, 10, 15, and 30 minutes.

Note, with the graph, times are rounded to the specified value; if no rounding value is specified, for purposes of graphing, they are rounded to the quarter-hour (i.e., 15 minutes). This is so the y-axis is intelligible. If `all` is selected with no rounding, the table will show in time (i.e., HH:MM), but the graph will have time rounded to the quarter-hour.