### PR TITLE
Fix up SQL code between mysql and sqlite.

### DIFF
--- a/add.py
+++ b/add.py
@@ -20,9 +20,17 @@ def run(args_dict):
         sys.exit(DB_ERROR_MESSAGE)
 
     if args_dict['close_entry']:
-        sql = ('''
-            update {table} set end="{time}" where id=(select max(id) from {table});
-        '''.format(table=args_dict['table'], time=args_dict['time']))
+        if args_dict['dbengine'] == 'mysql':
+            sql = ('''
+                select @last_row := max(id) from {table};
+                update {table} set end="{time}" where id=@last_row;
+            '''.format(table=args_dict['table'], time=args_dict['time']))
+        elif args_dict['dbengine'] == 'sqlite':
+            sql = ('''
+                update {table} set end="{time}" where id=(select max(id) from {table});
+            '''.format(table=args_dict['table'], time=args_dict['time']))
+        else:
+            sys.exit(DB_ERROR_MESSAGE)
         db.cursor().execute(sql)
     else:
         cur = db.cursor()


### PR DESCRIPTION
In one instance in the `add.py` script, the functioning of code between mysql
and sqlite differs and needs some logic to determine (a) what DB engine is
being used to (b) close out a time entry correctly.