### PR TITLE
Feature open and close record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.cfg
 *.pyc
 *.db
 .idea/
+*~


### PR DESCRIPTION
Adds a new command line option to insert a full record, i.e. a start and end time. Use case is for transcribing time entries from a separate source as opposed to real-time starting and stopping of time tracking. 

The new option, `-r`, has been defined to be mutually exclusive from the `-t` option. So `-t` is no longer a required argument, instead either `-r` or `-t` is required, but not both.